### PR TITLE
[#133674619] Provides a mechanism for migrating from 'or' to 'either' storage.

### DIFF
--- a/lib/paperclip/storage/eitheror.rb
+++ b/lib/paperclip/storage/eitheror.rb
@@ -16,6 +16,10 @@ module Paperclip
         @either.save
       end
 
+      def synced?
+        @either.exists?
+      end
+
       def path(style_name = default_style)
         usable_storage.path(style_name)
       end

--- a/lib/paperclip/storage/eitheror.rb
+++ b/lib/paperclip/storage/eitheror.rb
@@ -11,6 +11,11 @@ module Paperclip
         end
       end
 
+      def sync
+        @either.assign @or
+        @either.save
+      end
+
       def path(style_name = default_style)
         usable_storage.path(style_name)
       end

--- a/spec/paperclip/storage/eitheror_spec.rb
+++ b/spec/paperclip/storage/eitheror_spec.rb
@@ -149,7 +149,7 @@ describe Paperclip::Storage::Eitheror do
     end
   end
 
-  context 'when "syncing" an attachment' do
+  describe '#sync' do
     before { FileUtils.cp(source_image_path, fallback_image_path) }
 
     it 'copies asset from the "or" over to the "either" storage' do
@@ -158,6 +158,17 @@ describe Paperclip::Storage::Eitheror do
       expect(synced).to be_truthy
       expect(user.avatar.path).to match /primary_storage/
       expect(File.exists? user.avatar.path).to be_truthy
+    end
+  end
+
+  describe '#synced?' do
+    context 'when asset is not in the "either" storage' do
+      it { expect(user.avatar).to_not be_synced }
+    end
+
+    context 'when asset is in the "either" storage' do
+      before { FileUtils.cp(source_image_path, primary_storage_path) }
+      it { expect(user.avatar).to be_synced }
     end
   end
 end

--- a/spec/paperclip/storage/eitheror_spec.rb
+++ b/spec/paperclip/storage/eitheror_spec.rb
@@ -148,4 +148,16 @@ describe Paperclip::Storage::Eitheror do
       expect(avatar.an_unknown_method).to eq 'some result'
     end
   end
+
+  context 'when "syncing" an attachment' do
+    before { FileUtils.cp(source_image_path, fallback_image_path) }
+
+    it 'copies asset from the "or" over to the "either" storage' do
+      synced = user.avatar.sync
+
+      expect(synced).to be_truthy
+      expect(user.avatar.path).to match /primary_storage/
+      expect(File.exists? user.avatar.path).to be_truthy
+    end
+  end
 end


### PR DESCRIPTION
Implements migration mechanism proposal described at #3.

```
Given there is a User model
And   it has_attached_file :avatar using the "or" storage
When  I run user.avatar.sync
Then  the avatar's asset is copied from "or" to the "either" storage
```