### PR TITLE
Adds aliases ability

### DIFF
--- a/lib/paperclip/storage/eitheror.rb
+++ b/lib/paperclip/storage/eitheror.rb
@@ -5,6 +5,9 @@ module Paperclip
         base.instance_eval do
           @either = Attachment.new(base.name, base.instance, base.options.merge(base.options[:either]))
           @or = Attachment.new(base.name, base.instance, base.options.merge(base.options[:or]))
+
+          define_aliases @either, base.options[:either][:alias]
+          define_aliases @or, base.options[:or][:alias]
         end
       end
 
@@ -61,6 +64,16 @@ module Paperclip
           @either
         else
           either_exists ? @either : @or
+        end
+      end
+
+      def create_method(target, name, &block)
+        target.class.send(:define_method, name, &block)
+      end
+
+      def define_aliases target, aliases = {}
+        aliases.each do |name, value|
+          create_method(target, name) { |*args| target.send(value, *args) }
         end
       end
     end

--- a/lib/paperclip/storage/eitheror.rb
+++ b/lib/paperclip/storage/eitheror.rb
@@ -73,8 +73,15 @@ module Paperclip
 
       def define_aliases target, aliases = {}
         aliases.each do |name, value|
-          create_method(target, name) { |*args| target.send(value, *args) }
+          block = is_callable?(value) ?
+            ->(*args) { value.call(@either, @or, self, *args) } :
+            ->(*args) { target.send(value, *args) }
+          create_method(target, name, &block)
         end
+      end
+
+      def is_callable?(o)
+        o.respond_to?(:call)
       end
     end
   end

--- a/lib/paperclip/storage/eitheror.rb
+++ b/lib/paperclip/storage/eitheror.rb
@@ -67,10 +67,6 @@ module Paperclip
         end
       end
 
-      def create_method(target, name, &block)
-        target.class.send(:define_method, name, &block)
-      end
-
       def define_aliases target, aliases = {}
         aliases.each do |name, value|
           block = is_callable?(value) ?
@@ -82,6 +78,10 @@ module Paperclip
 
       def is_callable?(o)
         o.respond_to?(:call)
+      end
+
+      def create_method(target, name, &block)
+        target.class.send(:define_method, name, &block)
       end
     end
   end

--- a/spec/paperclip/storage/eitheror_spec.rb
+++ b/spec/paperclip/storage/eitheror_spec.rb
@@ -41,7 +41,6 @@ describe Paperclip::Storage::Eitheror do
 
   describe '#exists?' do
     subject(:avatar) { user.avatar }
-
     context 'when attachment is on "either"' do
       before { FileUtils.cp(source_image_path, primary_image_path) }
       it { expect(avatar.exists?).to be_truthy }
@@ -54,7 +53,7 @@ describe Paperclip::Storage::Eitheror do
 
     context "when attachment isn't anywhere" do
       it { expect(avatar.exists?).to be_falsy }
-      end
+    end
   end
 
   context 'when deleting' do
@@ -70,6 +69,9 @@ describe Paperclip::Storage::Eitheror do
   end
 
   context 'when "either" is available' do
+    before { FileUtils.cp(source_image_path, primary_image_path) }
+    subject(:avatar) { user.avatar }
+
     it 'deletes unknown call to "either" storage' do
       either_storage = double
       allow(either_storage).to receive(:exists?).and_return true
@@ -79,16 +81,38 @@ describe Paperclip::Storage::Eitheror do
 
       expect(user.avatar.some_unknown_method).to eq 'some response'
     end
+
+    context 'and an alias is set' do
+      it 'uses the aliased method' do
+        either_storage = user.avatar.instance_variable_get(:@either)
+        either_storage.stub(:either_handler)
+
+        expect(either_storage).to receive(:either_handler).with(:params)
+
+        user.avatar.only_on_or(:params)
+      end
+    end
   end
 
   context 'when "either" is not available' do
+    subject(:avatar) { user.avatar }
     context 'but "or" is' do
-
       before(:each) { FileUtils.cp(source_image_path, fallback_image_path)}
 
       it 'fallsback to "or" storage' do
         expect(user.avatar.path).to match fallback_storage_path
         expect(user.avatar.url).to match fallback_storage_url
+      end
+
+      context 'and an alias is set on "or"' do
+        it 'uses the aliased method' do
+          or_storage = avatar.instance_variable_get(:@or)
+          or_storage.stub(:or_handler)
+
+          expect(or_storage).to receive(:or_handler).with(:param)
+
+          user.avatar.only_on_either(:param)
+        end
       end
     end
 
@@ -97,9 +121,9 @@ describe Paperclip::Storage::Eitheror do
       allow(or_storage).to receive(:exists?).and_return true
       expect(or_storage).to receive(:an_unknown_method).and_return('some result')
 
-      user.avatar.instance_variable_set(:@or, or_storage)
+      avatar.instance_variable_set(:@or, or_storage)
 
-      expect(user.avatar.an_unknown_method).to eq 'some result'
+      expect(avatar.an_unknown_method).to eq 'some result'
     end
   end
 end

--- a/spec/paperclip/storage/eitheror_spec.rb
+++ b/spec/paperclip/storage/eitheror_spec.rb
@@ -91,6 +91,17 @@ describe Paperclip::Storage::Eitheror do
 
         user.avatar.only_on_or(:params)
       end
+
+      context 'and the alias is to a lambda' do
+        it 'calls the lambda with both storages and any extra arguments' do
+          user.avatar.either_lambda_alias(:param)
+
+          either_storage = user.avatar.instance_variable_get(:@either)
+          or_storage = avatar.instance_variable_get(:@or)
+
+          expect(User.instance_variable_get(:@either_lambda_called_with)).to eql [either_storage, or_storage, user.avatar, :param]
+        end
+      end
     end
   end
 
@@ -112,6 +123,17 @@ describe Paperclip::Storage::Eitheror do
           expect(or_storage).to receive(:or_handler).with(:param)
 
           user.avatar.only_on_either(:param)
+        end
+        
+        context 'and the alias is to a lambda' do
+          it 'calls the lambda with both storages and any extra arguments' do
+            user.avatar.either_lambda_alias(:param)
+
+            either_storage = user.avatar.instance_variable_get(:@either)
+            or_storage = avatar.instance_variable_get(:@or)
+
+            expect(User.instance_variable_get(:@either_lambda_called_with)).to eql [either_storage, or_storage, user.avatar, :param]
+          end
         end
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -30,7 +30,10 @@ class User < ActiveRecord::Base
       path: "spec/primary_storage/:filename",
       url: "/url/primary_storage/:filename",
       alias: {
-        only_on_or: :either_handler
+        only_on_or: :either_handler,
+        either_lambda_alias: ->(either_storage, or_storage, avatar, *args) do
+          self.instance_variable_set(:@either_lambda_called_with, [either_storage, or_storage, avatar, *args])
+        end
       }
     },
     or: {
@@ -38,7 +41,10 @@ class User < ActiveRecord::Base
       path: "spec/fallback_storage/:filename",
       url: "/url/fallback_storage/:filename",
       alias: {
-        only_on_either: :or_handler
+        only_on_either: :or_handler,
+        or_lambda_alias: ->(either_storage, or_storage, avatar, *args) do
+          self.instance_variable_set(:@or_lambda_called_with, [either_storage, or_storage, avatar, *args])
+        end
       }
     },
   }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -28,13 +28,19 @@ class User < ActiveRecord::Base
     either: {
       storage: :filesystem,
       path: "spec/primary_storage/:filename",
-      url: "/url/primary_storage/:filename"
+      url: "/url/primary_storage/:filename",
+      alias: {
+        only_on_or: :either_handler
+      }
     },
     or: {
       storage: :filesystem,
       path: "spec/fallback_storage/:filename",
-      url: "/url/fallback_storage/:filename"
-    }
+      url: "/url/fallback_storage/:filename",
+      alias: {
+        only_on_either: :or_handler
+      }
+    },
   }
 
   do_not_validate_attachment_file_type :avatar


### PR DESCRIPTION
Handles #9 

Allows for both storages to define method_aliases. 

You can either use a method name to which you wish to delegate calls, or use a `lambda` to implement custom behavior.
