### PR TITLE
Allow storage config without alias definition

### DIFF
--- a/lib/paperclip/storage/eitheror.rb
+++ b/lib/paperclip/storage/eitheror.rb
@@ -6,8 +6,8 @@ module Paperclip
           @either = Attachment.new(base.name, base.instance, base.options.merge(base.options[:either]))
           @or = Attachment.new(base.name, base.instance, base.options.merge(base.options[:or]))
 
-          define_aliases @either, base.options[:either][:alias]
-          define_aliases @or, base.options[:or][:alias]
+          define_aliases @either, base.options[:either].fetch(:alias, {})
+          define_aliases @or, base.options[:or].fetch(:alias, {})
         end
       end
 

--- a/spec/fixtures/user.rb
+++ b/spec/fixtures/user.rb
@@ -1,0 +1,31 @@
+class User < ActiveRecord::Base
+  include Paperclip::Glue
+
+  has_attached_file :avatar, {
+    storage: :eitheror,
+    either: {
+      storage: :filesystem,
+      path: "spec/primary_storage/:filename",
+      url: "/url/primary_storage/:filename",
+      alias: {
+        only_on_or: :either_handler,
+        either_lambda_alias: ->(either_storage, or_storage, avatar, *args) do
+          self.instance_variable_set(:@either_lambda_called_with, [either_storage, or_storage, avatar, *args])
+        end
+      }
+    },
+    or: {
+      storage: :filesystem,
+      path: "spec/fallback_storage/:filename",
+      url: "/url/fallback_storage/:filename",
+      alias: {
+        only_on_either: :or_handler,
+        or_lambda_alias: ->(either_storage, or_storage, avatar, *args) do
+          self.instance_variable_set(:@or_lambda_called_with, [either_storage, or_storage, avatar, *args])
+        end
+      }
+    },
+  }
+
+  do_not_validate_attachment_file_type :avatar
+end

--- a/spec/fixtures/user.rb
+++ b/spec/fixtures/user.rb
@@ -1,3 +1,5 @@
+require 'active_record'
+
 class User < ActiveRecord::Base
   include Paperclip::Glue
 
@@ -7,23 +9,11 @@ class User < ActiveRecord::Base
       storage: :filesystem,
       path: "spec/primary_storage/:filename",
       url: "/url/primary_storage/:filename",
-      alias: {
-        only_on_or: :either_handler,
-        either_lambda_alias: ->(either_storage, or_storage, avatar, *args) do
-          self.instance_variable_set(:@either_lambda_called_with, [either_storage, or_storage, avatar, *args])
-        end
-      }
     },
     or: {
       storage: :filesystem,
       path: "spec/fallback_storage/:filename",
       url: "/url/fallback_storage/:filename",
-      alias: {
-        only_on_either: :or_handler,
-        or_lambda_alias: ->(either_storage, or_storage, avatar, *args) do
-          self.instance_variable_set(:@or_lambda_called_with, [either_storage, or_storage, avatar, *args])
-        end
-      }
     },
   }
 

--- a/spec/fixtures/user_with_storage_alias.rb
+++ b/spec/fixtures/user_with_storage_alias.rb
@@ -1,0 +1,33 @@
+class UserWithStorageAlias < ActiveRecord::Base
+  include Paperclip::Glue
+
+  has_attached_file :avatar, {
+    storage: :eitheror,
+    either: {
+      storage: :filesystem,
+      path: "spec/primary_storage/:filename",
+      url: "/url/primary_storage/:filename",
+      alias: {
+        only_on_or: :either_handler,
+        either_lambda_alias: ->(either_storage, or_storage, avatar, *args) do
+          self.instance_variable_set(:@either_lambda_called_with, [either_storage, or_storage, avatar, *args])
+        end
+      }
+    },
+    or: {
+      storage: :filesystem,
+      path: "spec/fallback_storage/:filename",
+      url: "/url/fallback_storage/:filename",
+      alias: {
+        only_on_either: :or_handler,
+        or_lambda_alias: ->(either_storage, or_storage, avatar, *args) do
+          self.instance_variable_set(:@or_lambda_called_with, [either_storage, or_storage, avatar, *args])
+        end
+      }
+    },
+  }
+
+  do_not_validate_attachment_file_type :avatar
+end
+
+UserWithStorageAlias.table_name = "users"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,11 @@ require "paperclip-eitheror"
 
 require 'active_record'
 require 'paperclip'
+require 'byebug'
+
+Dir['spec/fixtures/*.rb'].each do |f|
+  require_relative "../#{f}"
+end
 
 ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
 
@@ -18,36 +23,4 @@ end
 Paperclip.options[:log] = false
 Paperclip.interpolates(:rails_root) do |a, _|
   Dir.tmpdir
-end
-
-class User < ActiveRecord::Base
-  include Paperclip::Glue
-
-  has_attached_file :avatar, {
-    storage: :eitheror,
-    either: {
-      storage: :filesystem,
-      path: "spec/primary_storage/:filename",
-      url: "/url/primary_storage/:filename",
-      alias: {
-        only_on_or: :either_handler,
-        either_lambda_alias: ->(either_storage, or_storage, avatar, *args) do
-          self.instance_variable_set(:@either_lambda_called_with, [either_storage, or_storage, avatar, *args])
-        end
-      }
-    },
-    or: {
-      storage: :filesystem,
-      path: "spec/fallback_storage/:filename",
-      url: "/url/fallback_storage/:filename",
-      alias: {
-        only_on_either: :or_handler,
-        or_lambda_alias: ->(either_storage, or_storage, avatar, *args) do
-          self.instance_variable_set(:@or_lambda_called_with, [either_storage, or_storage, avatar, *args])
-        end
-      }
-    },
-  }
-
-  do_not_validate_attachment_file_type :avatar
 end


### PR DESCRIPTION
@mpabegg it seems the [define_aliases default parameter](https://github.com/powerhome/paperclip-eitheror/blob/feature/allow-config-without-aliases/lib/paperclip/storage/eitheror.rb#L79) isn't really working.

This PR simply uses `Hash#fetch` to fetch storage config or use a default value, in this case for the alias definition.