### PR TITLE
Feature/auto sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,20 @@ class User < ActiveRecord::Base
 end
 ```
 
+# `:autosync`
+
+You can configure `paperclip-eitheror` to automatically synchronize attachments from the **or** (fallback) storage to **either** (primary).
+
+When `:autosync` is set to `true`, whenever an attachment which exists only on **or** is accessed, the attachment will be synced to the primary storage and access (such as `path` and `url`) will be provided through the primary storage.
+
+```ruby
+has_attached_file :avatar, {
+  storage: :eitheror,
+  autosync: true,
+  ...
+}
+```
+
 # Method aliasing/overriding
 
 Different storages provide different ways of accessing attachments.

--- a/lib/paperclip/storage/eitheror.rb
+++ b/lib/paperclip/storage/eitheror.rb
@@ -72,7 +72,13 @@ module Paperclip
         if !(either_exists || or_exists)
           @either
         else
-          either_exists ? @either : @or
+          if either_exists
+            @either
+          elsif options[:autosync]
+            (sync && @either) || @or
+          else
+            @or
+          end
         end
       end
 

--- a/lib/paperclip/storage/eitheror.rb
+++ b/lib/paperclip/storage/eitheror.rb
@@ -69,17 +69,9 @@ module Paperclip
         either_exists = @either.exists?
         or_exists = @or.exists?
 
-        if !(either_exists || or_exists)
-          @either
-        else
-          if either_exists
-            @either
-          elsif options[:autosync]
-            (sync && @either) || @or
-          else
-            @or
-          end
-        end
+        return @either if either_exists || !or_exists
+
+        options[:autosync] && sync ? @either : @or
       end
 
       def define_aliases target, aliases = {}

--- a/spec/paperclip/storage/eitheror_spec.rb
+++ b/spec/paperclip/storage/eitheror_spec.rb
@@ -141,6 +141,29 @@ describe Paperclip::Storage::Eitheror do
           end
         end
       end
+
+      context 'and :autosync is on' do
+        before do
+          options = avatar.instance_variable_get(:@options)
+          avatar.instance_variable_set(:@options, options.merge({autosync: true}))
+        end
+
+        it 'syncs the attachment' do
+          expect(avatar).to receive(:sync).and_call_original
+
+          expect(avatar.path).to match primary_storage_path
+          expect(avatar.url).to match primary_storage_url
+        end
+
+        context 'when #sync fails' do
+          before { allow(avatar).to receive(:sync).and_return false }
+
+          it 'fallsback to the "or" storage' do
+            expect(avatar.path).to match fallback_storage_path
+            expect(avatar.url).to match fallback_storage_url
+          end
+        end
+      end
     end
 
     it 'delegates unknown calls to "or" storage' do


### PR DESCRIPTION
Allows user to setup `:autosync`. 
When it's set to true, all attachments not available in `@either` will be synced upon access. 