### PR TITLE
Add support for checking whether an asset is syncable

### DIFF
--- a/lib/paperclip/storage/eitheror.rb
+++ b/lib/paperclip/storage/eitheror.rb
@@ -20,6 +20,10 @@ module Paperclip
         @either.exists?
       end
 
+      def syncable?
+        @or.exists?
+      end
+
       def path(style_name = default_style)
         usable_storage.path(style_name)
       end

--- a/lib/paperclip/storage/eitheror.rb
+++ b/lib/paperclip/storage/eitheror.rb
@@ -70,11 +70,7 @@ module Paperclip
       end
 
       def usable_storage
-        either_exists = @either.exists?
-        or_exists = @or.exists?
-
-        return @either if either_exists || !or_exists
-
+        return @either if !@or.exists? || @either.exists?
         options[:autosync] && sync ? @either : @or
       end
 

--- a/spec/paperclip/storage/eitheror_spec.rb
+++ b/spec/paperclip/storage/eitheror_spec.rb
@@ -199,4 +199,15 @@ describe Paperclip::Storage::Eitheror do
       it { expect(user.avatar).to be_synced }
     end
   end
+
+  describe '#syncable?' do
+    context 'when asset is present in the "or" storage' do
+      before { FileUtils.cp(source_image_path, fallback_storage_path) }
+      it { expect(user.avatar).to be_syncable }
+    end
+
+    context 'when asset is not present in the "or" storage' do
+      it { expect(user.avatar).to_not be_syncable }
+    end
+  end
 end

--- a/spec/paperclip/storage/eitheror_spec.rb
+++ b/spec/paperclip/storage/eitheror_spec.rb
@@ -90,7 +90,7 @@ describe Paperclip::Storage::Eitheror do
     context 'and an alias is set' do
       it 'uses the aliased method' do
         either_storage = avatar.instance_variable_get(:@either)
-        either_storage.stub(:either_handler)
+        allow(either_storage).to receive(:either_handler)
 
         expect(either_storage).to receive(:either_handler).with(:params)
 
@@ -123,7 +123,7 @@ describe Paperclip::Storage::Eitheror do
       context 'and an alias is set on "or"' do
         it 'uses the aliased method' do
           or_storage = avatar.instance_variable_get(:@or)
-          or_storage.stub(:or_handler)
+          allow(or_storage).to receive(:or_handler)
 
           expect(or_storage).to receive(:or_handler).with(:param)
 


### PR DESCRIPTION
This will allow any migration process to skip models whose attachment is optional and is not present, therefore, don't have any assets to be migrated.

Example:

```
Given I have a User model that has_attached_file :avatar
And the avatar attachment is optional
When I create a user with no avatar
Then user.avatar.syncable? returns false
```