### PR TITLE
Allow disabling the primary storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Paperclip::Eitheror
+
 [![Build Status](https://travis-ci.org/powerhome/paperclip-eitheror.svg?branch=master)](https://travis-ci.org/powerhome/paperclip-eitheror)
 
 A [Paperclip](https://github.com/thoughtbot/paperclip/) Storage which supports a secondary (called 'or') storage as a fallback while using the primary one (called 'either').
@@ -123,7 +124,7 @@ class User < ActiveRecord::Base
 end
 ```
 
-# `:autosync`
+## The `:autosync` Option
 
 You can configure `paperclip-eitheror` to automatically synchronize attachments from the **or** (fallback) storage to **either** (primary).
 
@@ -137,7 +138,30 @@ has_attached_file :avatar, {
 }
 ```
 
-# Method aliasing/overriding
+## Disabling "Either": The `enabled: false` Option
+
+In case you need to set up `paperclip-eitheror` on your app, but are not yet ready to enable the primary storage, you may disable it by using `enabled: false` in the **either** options list, as follows:
+
+```ruby
+has_attached_file :avatar, {
+  storage: :eitheror,
+  either: {
+    storage: :fog,
+    enabled: false,
+    path: ':attachment/:id/:style/:filename',
+    url: ':attachment/:id/:style/:filename'
+  },
+  or: {
+    storage: :filesystem,
+    url: '/api/v1/attachments/:attachment/:id/:style',
+    path: ':rails_root/public/attachments/:class/:attachment/:style/:filename',
+  }
+}
+```
+
+That comes specially handy if you need to enable/disable the primary storage based off a config flag, allowing, for instance, the primary storage to be disabled on a per-environment basis.
+
+## Method Aliasing/Overriding
 
 Different storages provide different ways of accessing attachments.
 For instance, when using `:fog` storage, you have access to methods which only make sense to that particular storage.

--- a/lib/paperclip/storage/eitheror.rb
+++ b/lib/paperclip/storage/eitheror.rb
@@ -3,6 +3,7 @@ module Paperclip
     module Eitheror
       def self.extended base
         base.instance_eval do
+          base.options[:either][:enabled] = true if base.options[:either][:enabled].nil?
           @either = Attachment.new(base.name, base.instance, base.options.merge(base.options[:either]))
           @or = Attachment.new(base.name, base.instance, base.options.merge(base.options[:or]))
 
@@ -70,6 +71,7 @@ module Paperclip
       end
 
       def usable_storage
+        return @or unless @either.options[:enabled]
         return @either if !@or.exists? || @either.exists?
         options[:autosync] && sync ? @either : @or
       end

--- a/spec/fixtures/user_with_disabled_either_storage.rb
+++ b/spec/fixtures/user_with_disabled_either_storage.rb
@@ -1,0 +1,22 @@
+class UserWithDisabledEitherStorage < ActiveRecord::Base
+  include Paperclip::Glue
+
+  has_attached_file :avatar, {
+    storage: :eitheror,
+    either: {
+      enabled: false,
+      storage: :filesystem,
+      path: "spec/primary_storage/:filename",
+      url: "/url/primary_storage/:filename",
+    },
+    or: {
+      storage: :filesystem,
+      path: "spec/fallback_storage/:filename",
+      url: "/url/fallback_storage/:filename",
+    },
+  }
+
+  do_not_validate_attachment_file_type :avatar
+end
+
+UserWithDisabledEitherStorage.table_name = "users"

--- a/spec/fixtures/user_with_enabled_either_storage.rb
+++ b/spec/fixtures/user_with_enabled_either_storage.rb
@@ -1,0 +1,22 @@
+class UserWithEnabledEitherStorage < ActiveRecord::Base
+  include Paperclip::Glue
+
+  has_attached_file :avatar, {
+    storage: :eitheror,
+    either: {
+      enabled: true,
+      storage: :filesystem,
+      path: "spec/primary_storage/:filename",
+      url: "/url/primary_storage/:filename",
+    },
+    or: {
+      storage: :filesystem,
+      path: "spec/fallback_storage/:filename",
+      url: "/url/fallback_storage/:filename",
+    },
+  }
+
+  do_not_validate_attachment_file_type :avatar
+end
+
+UserWithEnabledEitherStorage.table_name = "users"

--- a/spec/paperclip/storage/eitheror_spec.rb
+++ b/spec/paperclip/storage/eitheror_spec.rb
@@ -12,19 +12,15 @@ describe Paperclip::Storage::Eitheror do
   let(:primary_image_path) { "#{primary_storage_path}/image.jpg" }
   let(:fallback_image_path) { "#{fallback_storage_path}/image.jpg" }
 
-  let(:user) do
-    ActiveRecord::Base.connection.execute("INSERT into users (id, avatar_file_name, avatar_content_type) values (999, 'image.jpg', 'image/jpg')")
-    User.find(999)
-  end
-
-  let(:user_with_storage_alias) do
-    ActiveRecord::Base.connection.execute("INSERT into users (id, avatar_file_name, avatar_content_type) values (998, 'image.jpg', 'image/jpg')")
-    UserWithStorageAlias.find(998)
-  end
+  let(:user) { User.last }
+  let(:user_with_storage_alias) { UserWithStorageAlias.last }
+  let(:user_with_enabled_either_storage) { UserWithEnabledEitherStorage.last }
+  let(:user_with_disabled_either_storage) { UserWithDisabledEitherStorage.last }
 
   before(:each) do
     FileUtils.mkdir_p primary_storage_path
     FileUtils.mkdir_p fallback_storage_path
+    User.create avatar_file_name: 'image.jpg', avatar_content_type: 'image/jpg'
   end
 
   after(:each) do
@@ -73,16 +69,55 @@ describe Paperclip::Storage::Eitheror do
     end
   end
 
+  context 'when asset is present in both storages' do
+    before { FileUtils.cp(source_image_path, primary_image_path) }
+    before { FileUtils.cp(source_image_path, fallback_image_path) }
+
+    context 'and "either" storage is disabled' do
+      subject(:avatar) { user_with_disabled_either_storage.avatar }
+
+      it 'uses the "or" storage instead' do
+        or_storage = avatar.instance_variable_get(:@or)
+
+        usable_storage = avatar.send(:usable_storage)
+
+        expect(usable_storage).to eq or_storage
+      end
+    end
+
+    context 'and "either" storage is enabled' do
+      subject(:avatar) { user_with_enabled_either_storage.avatar }
+
+      it 'uses the "either" storage' do
+        either_storage = avatar.instance_variable_get(:@either)
+
+        usable_storage = avatar.send(:usable_storage)
+
+        expect(usable_storage).to eq either_storage
+      end
+    end
+
+    context 'and "either" storage is enabled by default' do
+      subject(:avatar) { user.avatar }
+
+      it 'uses the "either" storage' do
+        either_storage = avatar.instance_variable_get(:@either)
+
+        usable_storage = avatar.send(:usable_storage)
+
+        expect(usable_storage).to eq either_storage
+      end
+    end
+  end
+
   context 'when "either" is available' do
     before { FileUtils.cp(source_image_path, primary_image_path) }
     subject(:avatar) { user_with_storage_alias.avatar }
 
-    it 'delegates unknown calls to "either" storage' do
-      either_storage = double
-      allow(either_storage).to receive(:exists?).and_return true
-      expect(either_storage).to receive(:some_unknown_method).and_return('some response')
+    it 'delegates unknown calls on the model to the "either" storage' do
+      either_storage = avatar.instance_variable_get(:@either)
 
-      avatar.instance_variable_set(:@either, either_storage)
+      allow(either_storage).to receive(:some_unknown_method).and_return('some response')
 
       expect(avatar.some_unknown_method).to eq 'some response'
     end

--- a/spec/paperclip/storage/eitheror_spec.rb
+++ b/spec/paperclip/storage/eitheror_spec.rb
@@ -77,7 +77,7 @@ describe Paperclip::Storage::Eitheror do
     before { FileUtils.cp(source_image_path, primary_image_path) }
     subject(:avatar) { user_with_storage_alias.avatar }
 
-    it 'deletes unknown call to "either" storage' do
+    it 'delegates unknown calls to "either" storage' do
       either_storage = double
       allow(either_storage).to receive(:exists?).and_return true
       expect(either_storage).to receive(:some_unknown_method).and_return('some response')


### PR DESCRIPTION
Force usage of the **or** storage by disabling **either**.

This would support the use-case where one would like to leverage `paperclip-eitheror` so they can start migrating assets from **or** over to **either** offline, without having new ones written to **either** just yet, which is then disabled.