### PR TITLE
Provide storage that abstracts S3 assets as if they were local

### DIFF
--- a/lib/paperclip-eitheror.rb
+++ b/lib/paperclip-eitheror.rb
@@ -1,2 +1,3 @@
 require "paperclip/eitheror/version"
 require "paperclip/storage/eitheror"
+require "paperclip/storage/foggy"

--- a/lib/paperclip/storage/foggy.rb
+++ b/lib/paperclip/storage/foggy.rb
@@ -1,0 +1,31 @@
+module Paperclip
+  module Storage
+    module Foggy
+      def self.extended(base)
+        base.instance_eval do
+          @fog = Attachment.new(base.name, base.instance, @options.merge(storage: :fog))
+        end
+      end
+
+      def path(style_name = default_style)
+        Paperclip.io_adapters.for(short_expiring_url(style_name)).path
+      end
+
+      def fog_path(style_name = default_style)
+        @fog.path(style_name)
+      end
+
+      def url(style_name = default_style, options = {})
+        short_expiring_url(style_name)
+      end
+
+      def short_expiring_url(style_name = default_style)
+        @fog.expiring_url(Time.now.to_f + 3600, style_name)
+      end
+
+      def method_missing(method, *args)
+        @fog.send(method, *args)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is work in progress, so for more of a spike.

The idea is to provide a paperclip storage where assets can be manipulated as if they were local (relies on Paperclip::IOAdapters to do the trick), regardless of where it is remotely stored.


```
url = asset.url
=> https://s3-hq.powerhrg.com/nitro-devbox/support_ticket_attachments/uploads/229/original/sales-agreement.pdf?AWSAccessKeyId=GWNQSVNDSVYEMTU6EFPD&Signature=WZQIaey%2Ba8pgMGrzwYIz1aNGri8%3D&Expires=1480768274

file = asset.path
=> /var/tmp/sales-agreement.pdf
```

`asset.url` would return an S3 `short_expiring_url` which can be publicly accessed.
`asset.path` would first copy the remote file to a temporary local file (using the Paperclip::URIAdapter) and return the path to the local file instead of S3 path. That would allow existing code that relies of local files to still work. There might be some performance impact though since we'd be fetching the remote file.